### PR TITLE
Improve error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 rustls = ">=0.23.5, <0.24.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+thiserror = "1.0.61"
 tokio = { version = "1.37", features = ["full"] }
 
 [dev-dependencies]

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,7 @@ use crate::models::{LogitBias, Model, Role};
 use log::debug;
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use thiserror::Error;
 
 /// Main ChatGPTClient struct.
 pub struct ChatGPTClient {
@@ -91,27 +91,12 @@ pub struct Message {
 }
 
 /// Enum representing possible errors in the ChatGPTClient.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum ChatGPTError {
+    #[error("Request failed: {0}")]
     RequestFailed(String),
-    Reqwest(reqwest::Error),
-}
-
-impl fmt::Display for ChatGPTError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ChatGPTError::RequestFailed(message) => write!(f, "{message}"),
-            ChatGPTError::Reqwest(error) => write!(f, "Reqwest error: {error}"),
-        }
-    }
-}
-
-impl std::error::Error for ChatGPTError {}
-
-impl From<reqwest::Error> for ChatGPTError {
-    fn from(error: reqwest::Error) -> Self {
-        ChatGPTError::Reqwest(error)
-    }
+    #[error("Reqwest error: {0}")]
+    Reqwest(#[from] reqwest::Error),
 }
 
 impl ChatGPTClient {

--- a/src/models.rs
+++ b/src/models.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::fmt::Result as FmtResult;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
+use thiserror::Error;
 
 /// `Model` enum represents the available OpenAI models.
 ///
@@ -58,7 +59,7 @@ impl Display for Model {
 
 /// Implement `FromStr` to enable parsing the enum from a string representation.
 impl FromStr for Model {
-    type Err = ();
+    type Err = ModelError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -68,9 +69,17 @@ impl FromStr for Model {
             "gpt-4o" => Ok(Model::Gpt_4o),
             "gpt-4-1106-preview" => Ok(Model::Gpt_4Turbo),
             "gpt-4-vision-preview" => Ok(Model::Gpt_4Turbo_Vision),
-            _ => Err(()),
+            _ => Err(ModelError::UnsupportedModel(s.into())),
         }
     }
+}
+
+/// A model parsing issues.
+#[derive(Error, Debug)]
+pub enum ModelError {
+    /// Unknown or not supported model.
+    #[error("Unsupported model: {0}")]
+    UnsupportedModel(String),
 }
 
 /// `LogitBias` struct represents the logit bias used in API calls.


### PR DESCRIPTION
The PR improves `clap` compatibility and introduces the `thiserror` crate to improve error handling.

1. The `ChatGPTError` derives `Error` trait instead of declaring that manually. The extra benefit: it keeps original data of a failed request.
2. The new error `ModelError` is added and used instead of `()` for `FromStr` implementation of the `Model` enum. It's important to use `Error` compatible error if we want to allow to provide `Model` as a command line parameter using the `clap` crate.

Also instead of using `RequestFailed` error it's possible for the response to call the `error_for_status()` method to turn any not `OK` status into the `reqwest::Error`.